### PR TITLE
Adds logic to determine if "name" contains POI name or street address

### DIFF
--- a/src/main/java/com/mapzen/pelias/SimpleFeature.java
+++ b/src/main/java/com/mapzen/pelias/SimpleFeature.java
@@ -11,6 +11,8 @@ import auto.parcel.AutoParcel;
 
 @AutoParcel
 public abstract class SimpleFeature implements Parcelable {
+    public static final String ADDRESS_LAYER = "address";
+
     public static SimpleFeature create(
             String id,
             String name,
@@ -23,6 +25,7 @@ public abstract class SimpleFeature implements Parcelable {
             String locality,
             String neighborhood,
             String label,
+            String layer,
             double lat,
             double lng) {
 
@@ -37,6 +40,7 @@ public abstract class SimpleFeature implements Parcelable {
                 .locality(locality)
                 .neighborhood(neighborhood)
                 .label(label)
+                .layer(layer)
                 .lat(lat)
                 .lng(lng)
                 .build();
@@ -53,6 +57,7 @@ public abstract class SimpleFeature implements Parcelable {
     public abstract String locality();
     public abstract String neighborhood();
     public abstract String label();
+    public abstract String layer();
     public abstract double lat();
     public abstract double lng();
 
@@ -69,6 +74,7 @@ public abstract class SimpleFeature implements Parcelable {
         public abstract Builder locality(String locality);
         public abstract Builder neighborhood(String neighborhood);
         public abstract Builder label(String label);
+        public abstract Builder layer(String layer);
         public abstract Builder lat(double lat);
         public abstract Builder lng(double lng);
         public abstract SimpleFeature build();
@@ -93,6 +99,7 @@ public abstract class SimpleFeature implements Parcelable {
                 .locality(feature.properties.locality)
                 .neighborhood(feature.properties.neighbourhood)
                 .label(feature.properties.label)
+                .layer(feature.properties.layer)
                 .lat(feature.geometry.coordinates.get(1))
                 .lng(feature.geometry.coordinates.get(0))
                 .build();
@@ -118,6 +125,7 @@ public abstract class SimpleFeature implements Parcelable {
         properties.locality = locality();
         properties.neighbourhood = neighborhood();
         properties.label = label();
+        properties.layer = layer();
 
         geometry.coordinates.add(lng());
         geometry.coordinates.add(lat());
@@ -137,5 +145,9 @@ public abstract class SimpleFeature implements Parcelable {
 
     public static SimpleFeature readFromParcel(Parcel in) {
         return AutoParcel_SimpleFeature.CREATOR.createFromParcel(in);
+    }
+
+    public boolean isAddress() {
+        return ADDRESS_LAYER.equals(layer());
     }
 }

--- a/src/main/java/com/mapzen/pelias/gson/Properties.java
+++ b/src/main/java/com/mapzen/pelias/gson/Properties.java
@@ -12,4 +12,5 @@ public class Properties {
     public String locality = "";
     public String neighbourhood = "";
     public String label = "";
+    public String layer = "";
 }

--- a/src/test/java/com/mapzen/pelias/SimpleFeatureTest.java
+++ b/src/test/java/com/mapzen/pelias/SimpleFeatureTest.java
@@ -1,5 +1,9 @@
 package com.mapzen.pelias;
 
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.pelias.gson.Geometry;
+import com.mapzen.pelias.gson.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -25,6 +29,27 @@ public class SimpleFeatureTest {
         assertThat(getTestSimpleFeature().address()).isEqualTo("Manhattan, NY");
     }
 
+    @Test
+    public void fromFeature_shouldConstructFromFeatureObject() throws Exception {
+        assertThat(SimpleFeature.fromFeature(getTestFeature())).isEqualTo(getTestSimpleFeature());
+    }
+
+    @Test
+    public void isAddress_shouldReturnTrueIfResultIsFromAddressLayer() throws Exception {
+        Feature feature = getTestFeature();
+        feature.properties.layer = "address";
+        SimpleFeature simpleFeature = SimpleFeature.fromFeature(feature);
+        assertThat(simpleFeature.isAddress()).isTrue();
+    }
+
+    @Test
+    public void isAddress_shouldReturnFalseIfResultIsFromAnotherLayer() throws Exception {
+        Feature feature = getTestFeature();
+        feature.properties.layer = "locality";
+        SimpleFeature simpleFeature = SimpleFeature.fromFeature(feature);
+        assertThat(simpleFeature.isAddress()).isFalse();
+    }
+
     public static SimpleFeature getTestSimpleFeature() {
         return getTestSimpleFeature("Test SimpleFeature");
     }
@@ -44,6 +69,32 @@ public class SimpleFeatureTest {
                 .locality("New York")
                 .neighborhood("Koreatown")
                 .label("Test SimpleFeature, Manhattan, NY")
+                .layer("locality")
                 .build();
+    }
+
+    public static Feature getTestFeature() {
+        final Properties properties = new Properties();
+        properties.id = "123";
+        properties.name = "Test SimpleFeature";
+        properties.country = "United States";
+        properties.country_a = "USA";
+        properties.region = "New York";
+        properties.region_a = "NY";
+        properties.county = "New York County";
+        properties.localadmin = "Manhattan";
+        properties.locality = "New York";
+        properties.neighbourhood = "Koreatown";
+        properties.label = "Test SimpleFeature, Manhattan, NY";
+        properties.layer = "locality";
+
+        final Geometry geometry = new Geometry();
+        geometry.coordinates.add(1.0);
+        geometry.coordinates.add(1.0);
+
+        final Feature feature = new Feature();
+        feature.properties = properties;
+        feature.geometry = geometry;
+        return feature;
     }
 }


### PR DESCRIPTION
* Parses layer property in Pelias response
* Adds `SimpleFeature#isAddress()` method
* Returns `true` if feature is from address layer, `false` otherwise

Will be used to resolve https://github.com/mapzen/eraser-map/issues/137.

Closes #24