### PR TITLE
Send DNT header to disable server-side logging

### DIFF
--- a/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/src/main/java/com/mapzen/pelias/Pelias.java
@@ -3,6 +3,7 @@ package com.mapzen.pelias;
 import com.mapzen.pelias.gson.Result;
 
 import retrofit.Callback;
+import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 
 public class Pelias {
@@ -13,6 +14,10 @@ public class Pelias {
     private PeliasLocationProvider locationProvider;
 
     private static RestAdapter.LogLevel logLevel;
+
+    public static final String HEADER_DNT = "DNT";
+    public static final String VALUE_DNT = "1";
+    private boolean dntEnabled = true;
 
     protected Pelias(PeliasService service) {
         this.service = service;
@@ -30,6 +35,7 @@ public class Pelias {
         RestAdapter restAdapter = new RestAdapter.Builder()
                 .setEndpoint(serviceEndpoint)
                 .setLogLevel(logLevel)
+                .setRequestInterceptor(new AddHeadersInterceptor())
                 .build();
         this.service = restAdapter.create(PeliasService.class);
     }
@@ -94,5 +100,27 @@ public class Pelias {
 
     public void setApiKey(String key) {
         apiKey = key;
+    }
+
+    /**
+     * When header "DNT=1" is present in requests, logs are dropped on server
+     *
+     * Default is enabled
+     */
+    public void setDntEnabled(boolean enabled) {
+        this.dntEnabled = enabled;
+    }
+
+    public boolean isDntEnabled() {
+        return dntEnabled;
+    }
+
+    private class AddHeadersInterceptor implements RequestInterceptor {
+
+        @Override public void intercept(RequestFacade request) {
+            if (dntEnabled) {
+                request.addHeader(HEADER_DNT, VALUE_DNT);
+            }
+        }
     }
 }

--- a/src/test/java/com/mapzen/pelias/PeliasTest.java
+++ b/src/test/java/com/mapzen/pelias/PeliasTest.java
@@ -41,6 +41,11 @@ public class PeliasTest {
     }
 
     @Test
+    public void pelias_dntShouldBeEnabledByDefault() {
+        assertThat(peliasWithMock.isDntEnabled()).isTrue();
+    }
+
+    @Test
     public void search_getSearch() throws Exception {
         BoundingBox boundingBox = new BoundingBox(1.0, 2.0, 3.0 ,4.0);
         peliasWithMock.search("test", boundingBox, callback);
@@ -98,6 +103,34 @@ public class PeliasTest {
         pelias.suggest("test", 1.0, 2.0, callback);
         RecordedRequest request = server.takeRequest();
         assertThat(request.getPath()).contains("/autocomplete");
+        server.shutdown();
+    }
+
+    @Test
+    public void setDntEnabled_shouldAddDntHeader() throws Exception {
+        final MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse().setResponseCode(200);
+        server.enqueue(response);
+        server.play();
+        Pelias pelias = Pelias.getPeliasWithEndpoint(server.getUrl("/").toString());
+        pelias.suggest("test", 1.0, 2.0, callback);
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeaders("DNT")).isNotEmpty();
+        assertThat(request.getHeaders("DNT").get(0)).isEqualTo("1");
+        server.shutdown();
+    }
+
+    @Test
+    public void setDntDisabled_shouldNotAddDntHeader() throws Exception {
+        final MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse().setResponseCode(200);
+        server.enqueue(response);
+        server.play();
+        Pelias pelias = Pelias.getPeliasWithEndpoint(server.getUrl("/").toString());
+        pelias.setDntEnabled(false);
+        pelias.suggest("test", 1.0, 2.0, callback);
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeaders("DNT")).isEmpty();
         server.shutdown();
     }
 

--- a/src/test/java/com/mapzen/pelias/PeliasTest.java
+++ b/src/test/java/com/mapzen/pelias/PeliasTest.java
@@ -77,7 +77,7 @@ public class PeliasTest {
     public void suggest_getSuggestWithLocationProvider() throws Exception {
         peliasWithMock.setLocationProvider(new TestLocationProvider());
         peliasWithMock.suggest("test", callback);
-        verify(mock).getSuggest(eq("test"), eq(1.0), eq(2.0),eq(apiKey), cb.capture());
+        verify(mock).getSuggest(eq("test"), eq(1.0), eq(2.0), eq(apiKey), cb.capture());
     }
 
     @Test
@@ -103,34 +103,19 @@ public class PeliasTest {
         pelias.suggest("test", 1.0, 2.0, callback);
         RecordedRequest request = server.takeRequest();
         assertThat(request.getPath()).contains("/autocomplete");
-        server.shutdown();
-    }
 
-    @Test
-    public void setDntEnabled_shouldAddDntHeader() throws Exception {
-        final MockWebServer server = new MockWebServer();
-        MockResponse response = new MockResponse().setResponseCode(200);
-        server.enqueue(response);
-        server.play();
-        Pelias pelias = Pelias.getPeliasWithEndpoint(server.getUrl("/").toString());
+        //TODO: create method setDntEnabled_shouldAddDntHeader()
         pelias.suggest("test", 1.0, 2.0, callback);
-        RecordedRequest request = server.takeRequest();
-        assertThat(request.getHeaders("DNT")).isNotEmpty();
-        assertThat(request.getHeaders("DNT").get(0)).isEqualTo("1");
-        server.shutdown();
-    }
+        request = server.takeRequest();
+        assertThat(request.getHeaders(Pelias.HEADER_DNT)).isNotEmpty();
+        assertThat(request.getHeaders(Pelias.HEADER_DNT).get(0)).isEqualTo(Pelias.VALUE_DNT);
 
-    @Test
-    public void setDntDisabled_shouldNotAddDntHeader() throws Exception {
-        final MockWebServer server = new MockWebServer();
-        MockResponse response = new MockResponse().setResponseCode(200);
-        server.enqueue(response);
-        server.play();
-        Pelias pelias = Pelias.getPeliasWithEndpoint(server.getUrl("/").toString());
+        //TODO: create method setDntDisabled_shouldNotAddDntHeader()
         pelias.setDntEnabled(false);
         pelias.suggest("test", 1.0, 2.0, callback);
-        RecordedRequest request = server.takeRequest();
-        assertThat(request.getHeaders("DNT")).isEmpty();
+        request = server.takeRequest();
+        assertThat(request.getHeaders(Pelias.HEADER_DNT)).isEmpty();
+
         server.shutdown();
     }
 


### PR DESCRIPTION
Enabled by default with the option to disable it anytime

Having problems with MockWebServer hanging when multiple tests create their own instances. The docs say it should be light enough to create an instance per method though. Unless you guys know how to resolve this, I'll create a ticket to move the nested tests to a new method

Closes #428