### PR TITLE
Return substring of label if string is full address, not coordinates

### DIFF
--- a/src/main/java/com/mapzen/pelias/SimpleFeature.java
+++ b/src/main/java/com/mapzen/pelias/SimpleFeature.java
@@ -116,7 +116,11 @@ public abstract class SimpleFeature implements Parcelable {
     }
 
     public String address() {
-        return label().substring(label().indexOf(", ") + 2);
+        int commaIndex = label().indexOf(", ");
+        if (commaIndex != -1) {
+            return label().substring(commaIndex + 2);
+        }
+        return label();
     }
 
     public Feature toFeature() {


### PR DESCRIPTION
When a feature's label is "1200 Lawry Lane, Boulder, CO, USA" for example, "Boulder, CO, USA" will be returned and when a feature's label is "32.838,-125.79", "32.838,-125.79" will be returned