### PR TITLE
Remove api keys and dnt headers from Pelias, replace with PeliasService

### DIFF
--- a/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/src/main/java/com/mapzen/pelias/Pelias.java
@@ -31,12 +31,16 @@ public class Pelias {
             .setRequestInterceptor(new RequestInterceptor() {
                 @Override public void intercept(RequestFacade request) {
                     if (requestHandler != null) {
-                        for (String key : requestHandler.headersForRequest().keySet()) {
-                            request.addHeader(key, requestHandler.headersForRequest().get(key));
+                        if (requestHandler.headersForRequest() != null) {
+                            for (String key : requestHandler.headersForRequest().keySet()) {
+                                request.addHeader(key, requestHandler.headersForRequest().get(key));
+                            }
                         }
-                        for (String key : requestHandler.queryParamsForRequest().keySet()) {
-                            request.addQueryParam(key, requestHandler.queryParamsForRequest()
-                                .get(key));
+                        if (requestHandler.queryParamsForRequest() != null) {
+                            for (String key : requestHandler.queryParamsForRequest().keySet()) {
+                                request.addQueryParam(key, requestHandler.queryParamsForRequest()
+                                    .get(key));
+                            }
                         }
                     }
                 }

--- a/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/src/main/java/com/mapzen/pelias/Pelias.java
@@ -11,13 +11,42 @@ public class Pelias {
 
     private PeliasService service;
     private PeliasLocationProvider locationProvider;
+    private PeliasRequestHandler requestHandler;
 
     public Pelias() {
-
+        initService(DEFAULT_SEARCH_ENDPOINT);
     }
 
-    public void setService(PeliasService service) {
+    public Pelias(PeliasService service) {
         this.service = service;
+    }
+
+    public Pelias(String url) {
+        initService(url);
+    }
+
+    private void initService(String endpoint) {
+        RestAdapter adapter = new RestAdapter.Builder()
+            .setEndpoint(endpoint)
+            .setRequestInterceptor(new RequestInterceptor() {
+                @Override public void intercept(RequestFacade request) {
+                    if (requestHandler != null) {
+                        for (String key : requestHandler.headersForRequest().keySet()) {
+                            request.addHeader(key, requestHandler.headersForRequest().get(key));
+                        }
+                        for (String key : requestHandler.queryParamsForRequest().keySet()) {
+                            request.addQueryParam(key, requestHandler.queryParamsForRequest()
+                                .get(key));
+                        }
+                    }
+                }
+            })
+            .build();
+        this.service = adapter.create(PeliasService.class);
+    }
+
+    public void setRequestHandler(PeliasRequestHandler handler) {
+        requestHandler = handler;
     }
 
     public void suggest(String query, Callback<Result> callback) {

--- a/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/src/main/java/com/mapzen/pelias/Pelias.java
@@ -7,63 +7,17 @@ import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 
 public class Pelias {
+    public static final String DEFAULT_SEARCH_ENDPOINT = "https://search.mapzen.com/v1/";
+
     private PeliasService service;
-    public static final String DEFAULT_SERVICE_ENDPOINT = "https://search.mapzen.com/v1/";
-    private String apiKey = "";
-    private static Pelias instance = null;
     private PeliasLocationProvider locationProvider;
 
-    private static RestAdapter.LogLevel logLevel;
+    public Pelias() {
 
-    public static final String HEADER_DNT = "DNT";
-    public static final String VALUE_DNT = "1";
-    private boolean dntEnabled = true;
+    }
 
-    protected Pelias(PeliasService service) {
+    public void setService(PeliasService service) {
         this.service = service;
-    }
-
-    private Pelias(String endpoint) {
-        initService(endpoint);
-    }
-
-    private Pelias() {
-        initService(DEFAULT_SERVICE_ENDPOINT);
-    }
-
-    private void initService(String serviceEndpoint) {
-        RestAdapter restAdapter = new RestAdapter.Builder()
-                .setEndpoint(serviceEndpoint)
-                .setLogLevel(logLevel)
-                .setRequestInterceptor(new AddHeadersInterceptor())
-                .build();
-        this.service = restAdapter.create(PeliasService.class);
-    }
-
-    public static Pelias getPeliasWithEndpoint(String endpoint) {
-        return getPeliasWithEndpoint(endpoint, RestAdapter.LogLevel.NONE);
-    }
-
-    public static Pelias getPelias() {
-        return getPelias(RestAdapter.LogLevel.NONE);
-    }
-
-    public static Pelias getPeliasWithEndpoint(String endpoint, RestAdapter.LogLevel logLevel) {
-        Pelias.logLevel = logLevel;
-
-        if (instance == null) {
-            instance = new Pelias(endpoint);
-        }
-        return instance;
-    }
-
-    public static Pelias getPelias(RestAdapter.LogLevel logLevel) {
-        Pelias.logLevel = logLevel;
-
-        if (instance == null) {
-            instance = new Pelias();
-        }
-        return instance;
     }
 
     public void suggest(String query, Callback<Result> callback) {
@@ -71,7 +25,7 @@ public class Pelias {
     }
 
     public void suggest(String query, double lat, double lon, Callback<Result> callback) {
-        service.getSuggest(query, lat, lon, apiKey, callback);
+        service.getSuggest(query, lat, lon, callback);
     }
 
     public void search(String query, Callback<Result> callback) {
@@ -79,48 +33,23 @@ public class Pelias {
     }
 
     public void search(String query, BoundingBox box, Callback<Result> callback) {
-        service.getSearch(query, box.minLat, box.minLon, box.maxLat, box.maxLon, apiKey, callback);
+        service.getSearch(query, box.minLat, box.minLon, box.maxLat, box.maxLon, callback);
     }
 
     public void search(String query, double lat, double lon, Callback<Result> callback) {
-        service.getSearch(query, lat, lon, apiKey, callback);
+        service.getSearch(query, lat, lon, callback);
     }
 
     public void reverse(double lat, double lon, Callback<Result> callback) {
-        service.getReverse(lat, lon, apiKey, callback);
+        service.getReverse(lat, lon, callback);
     }
 
     public void place(String gid, Callback<Result> callback) {
-        service.getPlace(gid, apiKey, callback);
+        service.getPlace(gid, callback);
     }
 
     public void setLocationProvider(PeliasLocationProvider locationProvider) {
         this.locationProvider = locationProvider;
     }
 
-    public void setApiKey(String key) {
-        apiKey = key;
-    }
-
-    /**
-     * When header "DNT=1" is present in requests, logs are dropped on server
-     *
-     * Default is enabled
-     */
-    public void setDntEnabled(boolean enabled) {
-        this.dntEnabled = enabled;
-    }
-
-    public boolean isDntEnabled() {
-        return dntEnabled;
-    }
-
-    private class AddHeadersInterceptor implements RequestInterceptor {
-
-        @Override public void intercept(RequestFacade request) {
-            if (dntEnabled) {
-                request.addHeader(HEADER_DNT, VALUE_DNT);
-            }
-        }
-    }
 }

--- a/src/main/java/com/mapzen/pelias/PeliasRequestHandler.java
+++ b/src/main/java/com/mapzen/pelias/PeliasRequestHandler.java
@@ -1,0 +1,9 @@
+package com.mapzen.pelias;
+
+import java.util.Map;
+
+public interface PeliasRequestHandler {
+
+  Map<String, String> headersForRequest();
+  Map<String, String> queryParamsForRequest();
+}

--- a/src/main/java/com/mapzen/pelias/PeliasService.java
+++ b/src/main/java/com/mapzen/pelias/PeliasService.java
@@ -12,7 +12,6 @@ public interface PeliasService {
             @Query("text") String query,
             @Query("focus.point.lat") double lat,
             @Query("focus.point.lon") double lon,
-            @Query("api_key") String key,
             Callback<Result> callback);
 
     @GET("/search")
@@ -22,7 +21,6 @@ public interface PeliasService {
             @Query("focus.viewport.min_lon") double minLon,
             @Query("focus.viewport.max_lat") double maxLat,
             @Query("focus.viewport.max_lon") double maxLon,
-            @Query("api_key") String key,
             Callback<Result> callback);
 
     @GET("/search")
@@ -30,18 +28,15 @@ public interface PeliasService {
             @Query("text") String query,
             @Query("focus.point.lat") double lat,
             @Query("focus.point.lon") double lon,
-            @Query("api_key") String key,
             Callback<Result> callback);
 
     @GET("/reverse")
     void getReverse(
             @Query("point.lat") double lat,
             @Query("point.lon") double lon,
-            @Query("api_key") String key,
             Callback<Result> callback);
 
     @GET("/place")
     void getPlace(@Query("ids") String ids,
-            @Query("api_key") String key,
             Callback<Result> callback);
 }

--- a/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
+++ b/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
@@ -274,7 +274,9 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
 
         final AutoCompleteAdapter adapter = (AutoCompleteAdapter) autoCompleteListView.getAdapter();
         adapter.clear();
-        adapter.addAll(savedSearch.getItems());
+        if (savedSearch != null) {
+            adapter.addAll(savedSearch.getItems());
+        }
         adapter.notifyDataSetChanged();
     }
 

--- a/src/test/java/com/mapzen/pelias/PeliasTest.java
+++ b/src/test/java/com/mapzen/pelias/PeliasTest.java
@@ -16,21 +16,17 @@ import org.mockito.MockitoAnnotations;
 import java.util.HashMap;
 import java.util.Map;
 
-import retrofit.Callback;
-import retrofit.RequestInterceptor;
-import retrofit.RestAdapter;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
-
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
 
 public class PeliasTest {
     Pelias peliasWithMock;
     TestCallback callback;
     PeliasService mock;
-    String apiKey = "test_key";
 
     @Captor
     @SuppressWarnings("unused")

--- a/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
+++ b/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
@@ -1,7 +1,5 @@
 package com.mapzen.pelias.widget;
 
-import android.view.KeyEvent;
-import android.view.ViewGroup;
 import com.mapzen.pelias.BuildConfig;
 import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.PeliasService;
@@ -29,8 +27,6 @@ import retrofit.Callback;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 import retrofit.http.Query;
-
-import java.lang.reflect.Method;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
@@ -309,7 +305,8 @@ public class PeliasSearchViewTest {
 
     private class TestPelias extends Pelias {
         protected TestPelias() {
-            super(new TestPeliasService());
+            super();
+            setService(new TestPeliasService());
         }
     }
 
@@ -318,7 +315,7 @@ public class PeliasSearchViewTest {
                 @Query("text") String query,
                 @Query("focus.point.lat") double lat,
                 @Query("focus.point.lon") double lon,
-                @Query("api_key") String key, Callback<Result> callback) {
+                Callback<Result> callback) {
             callback.success(new Result(), null);
         }
 
@@ -328,7 +325,7 @@ public class PeliasSearchViewTest {
                 @Query("focus.viewport.min_lat") double minLat,
                 @Query("focus.viewport.max_lon") double maxLon,
                 @Query("focus.viewport.max_lat") double maxLat,
-                @Query("api_key") String key, Callback<Result> callback) {
+                Callback<Result> callback) {
             callback.success(new Result(), null);
         }
 
@@ -336,20 +333,20 @@ public class PeliasSearchViewTest {
                 @Query("text") String query,
                 @Query("focus.point.lat") double lat,
                 @Query("focus.point.lon") double lon,
-                @Query("api_key") String key, Callback<Result> callback) {
+                Callback<Result> callback) {
             callback.success(new Result(), null);
         }
 
         @Override public void getReverse(
                 @Query("point.lat") double lat,
                 @Query("point.lon") double lon,
-                @Query("api_key") String key, Callback<Result> callback) {
+                Callback<Result> callback) {
             callback.success(new Result(), null);
         }
 
         @Override public void getPlace(
                 @Query("ids") String ids,
-                @Query("api_key") String key, Callback<Result> callback) {
+                Callback<Result> callback) {
             callback.success(new Result(), null);
         }
     }

--- a/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
+++ b/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
@@ -305,8 +305,7 @@ public class PeliasSearchViewTest {
 
     private class TestPelias extends Pelias {
         protected TestPelias() {
-            super();
-            setService(new TestPeliasService());
+            super(new TestPeliasService());
         }
     }
 


### PR DESCRIPTION
Api key can now be set via the `RestAdapter` used to create the `PeliasService` using a `RequestInterceptor` like this:

```
RestAdapter restAdapter = new RestAdapter.Builder().setEndpoint(
        Pelias.DEFAULT_SEARCH_ENDPOINT).setRequestInterceptor(new RequestInterceptor() {
      @Override public void intercept(RequestFacade request) {
        request.addQueryParam("api_key", "EXAMPLE_API_KEY");
      }
    }).build();
    pelias.setService(restAdapter.create(PeliasService.class));
```