### PR TITLE
Allow Filtering Results

### DIFF
--- a/app/src/main/java/com/mapzen/sample/pelias/MainActivity.java
+++ b/app/src/main/java/com/mapzen/sample/pelias/MainActivity.java
@@ -3,6 +3,7 @@ package com.mapzen.sample.pelias;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.PeliasLocationProvider;
+import com.mapzen.pelias.SuggestFilter;
 import com.mapzen.pelias.gson.Result;
 import com.mapzen.pelias.widget.AutoCompleteAdapter;
 import com.mapzen.pelias.widget.AutoCompleteListView;
@@ -82,5 +83,18 @@ public class MainActivity extends AppCompatActivity {
     });
     searchView.setIconifiedByDefault(false);
     searchView.setQueryHint(this.getString(R.string.search_hint));
+    searchView.setSuggestFilter(new SuggestFilter() {
+      @Override public String getCountryFilter() {
+        return "FR";
+      }
+
+      @Override public String getLayersFilter() {
+        return "address,venue";
+      }
+
+      @Override public String getSources() {
+        return "wof,osm,oa,gn";
+      }
+    });
   }
 }

--- a/lib/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/lib/src/main/java/com/mapzen/pelias/Pelias.java
@@ -107,6 +107,18 @@ public class Pelias {
   }
 
   /**
+   * Returns autocomplete suggestions given a query string. The query will use the
+   * {@link PeliasLocationProvider} to retrieve a lat/lon to use as a focus point for the request.
+   * Results will be limited by the layers, country, and sources strings. The callback will be
+   * notified upon success or failure of query.
+   */
+  public void suggest(String query, String layers, String country, String sources,
+      Callback<Result> callback) {
+    service.getSuggest(query, locationProvider.getLat(), locationProvider.getLon(), layers, country,
+        sources).enqueue(callback);
+  }
+
+  /**
    * Requests autocomplete suggestions given a query and lat/lon. The lat/lon is used as a focus
    * point for results The callback will be notified upon success or failure of the query.
    */
@@ -148,6 +160,14 @@ public class Pelias {
    */
   public void reverse(double lat, double lon, Callback<Result> callback) {
     service.getReverse(lat, lon).enqueue(callback);
+  }
+
+  /**
+   * Issues a reverse geocode request given the lat/lon and limited to the sources. The callback
+   * will be notified upon success or failure of the query.
+   */
+  public void reverse(double lat, double lon, String sources, Callback<Result> callback) {
+    service.getReverse(lat, lon, sources).enqueue(callback);
   }
 
   /**

--- a/lib/src/main/java/com/mapzen/pelias/PeliasService.java
+++ b/lib/src/main/java/com/mapzen/pelias/PeliasService.java
@@ -15,7 +15,19 @@ public interface PeliasService {
    * Asynchronously request autocomplete results given a query and focus point.
    */
   @GET("/v1/autocomplete") Call<Result> getSuggest(@Query("text") String query,
-      @Query("focus.point.lat") double lat, @Query("focus.point.lon") double lon);
+      @Query("focus.point.lat") double lat,
+      @Query("focus.point.lon") double lon);
+
+  /**
+   * Asynchronously request autocomplete results given a query andfocus point.
+   * Limit results by layer and country.
+   */
+  @GET("/v1/autocomplete") Call<Result> getSuggest(@Query("text") String query,
+      @Query("focus.point.lat") double lat,
+      @Query("focus.point.lon") double lon,
+      @Query("layers") String layers,
+      @Query("boundary.country") String country,
+      @Query("sources") String source);
 
   /**
    * Asynchronously request search results given a query and bounding box.
@@ -38,6 +50,13 @@ public interface PeliasService {
    */
   @GET("/v1/reverse") Call<Result> getReverse(@Query("point.lat") double lat,
       @Query("point.lon") double lon);
+
+  /**
+   * Asynchronously issue reverse geocode request.
+   */
+  @GET("/v1/reverse") Call<Result> getReverse(@Query("point.lat") double lat,
+      @Query("point.lon") double lon,
+      @Query("sources") String sources);
 
   /**
    * Asynchronously request more information about places given their global unique identifiers.

--- a/lib/src/main/java/com/mapzen/pelias/SuggestFilter.java
+++ b/lib/src/main/java/com/mapzen/pelias/SuggestFilter.java
@@ -1,0 +1,28 @@
+package com.mapzen.pelias;
+
+/**
+ * Interface to optionally limit autocomplete results on a
+ * {@link com.mapzen.pelias.widget.PeliasSearchView}.
+ */
+public interface SuggestFilter {
+
+  /**
+   * Return a string in the alpha-2 or alpha-3 ISO-3166 country code format.
+   * @return
+   */
+  String getCountryFilter();
+
+  /**
+   * Return a comma-delimited string. For a list of valid layers, see:
+   * https://mapzen.com/documentation/search/autocomplete/
+   * @return
+   */
+  String getLayersFilter();
+
+  /**
+   * Return a comma-delimited string. For a list of valid sources, see:
+   * https://mapzen.com/documentation/search/reverse/#filter-by-data-source
+   * @return
+   */
+  String getSources();
+}

--- a/lib/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
+++ b/lib/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
@@ -7,6 +7,7 @@ import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.R;
 import com.mapzen.pelias.SavedSearch;
 import com.mapzen.pelias.SimpleFeature;
+import com.mapzen.pelias.SuggestFilter;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Result;
 
@@ -84,6 +85,7 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
   private OnBackPressListener onBackPressListener;
   private boolean cacheSearchResults = true;
   private boolean autoKeyboardShow = true;
+  private SuggestFilter suggestFilter;
 
   private Callback<Result> suggestCallback = new Callback<Result>() {
     @Override public void onResponse(Call<Result> call, Response<Result> response) {
@@ -133,6 +135,14 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
     disableDefaultSoftKeyboardBehaviour();
     setOnQueryTextListener(this);
     setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+  }
+
+  /**
+   * Set a filter to use when querying for autocomplete results.
+   * @param suggestFilter
+   */
+  public void setSuggestFilter(SuggestFilter suggestFilter) {
+    this.suggestFilter = suggestFilter;
   }
 
   /**
@@ -261,8 +271,12 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
     if (pelias == null) {
       return;
     }
-
-    pelias.suggest(text, suggestCallback);
+    if (suggestFilter == null) {
+      pelias.suggest(text, suggestCallback);
+    } else {
+      pelias.suggest(text, suggestFilter.getLayersFilter(), suggestFilter.getCountryFilter(),
+          suggestFilter.getSources(), suggestCallback);
+    }
   }
 
   /**

--- a/lib/src/test/java/com/mapzen/pelias/PeliasTest.java
+++ b/lib/src/test/java/com/mapzen/pelias/PeliasTest.java
@@ -77,11 +77,26 @@ public class PeliasTest {
     verify(mock).getSuggest(eq("test"), eq(1.0), eq(2.0));
   }
 
+  @Test public void suggest_getSuggestWithLayersCountrySources() throws Exception {
+    when(mock.getSuggest(anyString(), anyDouble(), anyDouble(), anyString(), anyString(),
+        anyString())).thenReturn(new TestCall());
+    peliasWithMock.setLocationProvider(new TestLocationProvider());
+    peliasWithMock.suggest("test", "venue", "us", "wof", callback);
+    verify(mock).getSuggest(eq("test"), eq(1.0), eq(2.0), eq("venue"), eq("us"), eq("wof"));
+  }
+
   @Test public void reverse_getReverseGeocode() throws Exception {
     when(mock.getReverse(anyDouble(), anyDouble())).thenReturn(new TestCall());
     peliasWithMock.setLocationProvider(new TestLocationProvider());
     peliasWithMock.reverse(30.0, 40.0, callback);
     verify(mock).getReverse(eq(30.0), eq(40.0));
+  }
+
+  @Test public void reverse_getReverseGeocodeWithSources() throws Exception {
+    when(mock.getReverse(anyDouble(), anyDouble(), anyString())).thenReturn(new TestCall());
+    peliasWithMock.setLocationProvider(new TestLocationProvider());
+    peliasWithMock.reverse(30.0, 40.0, "wof", callback);
+    verify(mock).getReverse(eq(30.0), eq(40.0), eq("wof"));
   }
 
   @Test public void place_shouldSendSearchRequestToServer() throws Exception {

--- a/lib/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
+++ b/lib/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
@@ -312,6 +312,13 @@ public class PeliasSearchViewTest {
       return new TestCall();
     }
 
+    @Override public Call<Result> getSuggest(@Query("text") String query,
+        @Query("focus.point.lat") double lat, @Query("focus.point.lon") double lon,
+        @Query("layers") String layers, @Query("boundary.country") String country,
+        @Query("sources") String source) {
+      return new TestCall();
+    }
+
     @Override public Call<Result> getSearch(@Query("text") String query,
         @Query("focus.viewport.min_lon") double minLon,
         @Query("focus.viewport.min_lat") double minLat,
@@ -327,6 +334,12 @@ public class PeliasSearchViewTest {
 
     @Override public Call<Result> getReverse(@Query("point.lat") double lat,
         @Query("point.lon") double lon) {
+      return new TestCall();
+    }
+
+    @Override
+    public Call<Result> getReverse(@Query("point.lat") double lat, @Query("point.lon") double lon,
+        @Query("sources") String sources) {
       return new TestCall();
     }
 
@@ -376,6 +389,13 @@ public class PeliasSearchViewTest {
       return new TestEmptyCall();
     }
 
+    @Override public Call<Result> getSuggest(@Query("text") String query,
+        @Query("focus.point.lat") double lat, @Query("focus.point.lon") double lon,
+        @Query("layers") String layers, @Query("boundary.country") String country,
+        @Query("sources") String source) {
+      return new TestEmptyCall();
+    }
+
     @Override public Call<Result> getSearch(@Query("text") String query,
         @Query("focus.viewport.min_lon") double minLon,
         @Query("focus.viewport.min_lat") double minLat,
@@ -391,6 +411,12 @@ public class PeliasSearchViewTest {
 
     @Override public Call<Result> getReverse(@Query("point.lat") double lat,
         @Query("point.lon") double lon) {
+      return new TestEmptyCall();
+    }
+
+    @Override
+    public Call<Result> getReverse(@Query("point.lat") double lat, @Query("point.lon") double lon,
+        @Query("sources") String sources) {
       return new TestEmptyCall();
     }
 


### PR DESCRIPTION
### Overview
Allow clients to limit autocomplete and reverse geo results.

### Proposed Changes
Adds an interface (`SuggestFilter`) to allow client specification of layers, country, and sources when `PeliasSearchView` is autocompleting. Also adds two new methods to `PeliasService` to allow limiting autocomplete and reverse geo results on `Pelias` objects.