### PR TITLE
Allow custom behavior when search clicked

### DIFF
--- a/app/src/main/java/com/mapzen/sample/pelias/MainActivity.java
+++ b/app/src/main/java/com/mapzen/sample/pelias/MainActivity.java
@@ -8,6 +8,7 @@ import com.mapzen.pelias.gson.Result;
 import com.mapzen.pelias.widget.AutoCompleteAdapter;
 import com.mapzen.pelias.widget.AutoCompleteListView;
 import com.mapzen.pelias.widget.PeliasSearchView;
+import com.mapzen.pelias.widget.SearchSubmitListener;
 
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
@@ -94,6 +95,15 @@ public class MainActivity extends AppCompatActivity {
 
       @Override public String getSources() {
         return "wof,osm,oa,gn";
+      }
+    });
+    searchView.setSearchSubmitListener(new SearchSubmitListener() {
+      @Override public boolean searchOnSearchKeySubmit() {
+        return false;
+      }
+
+      @Override public boolean hideAutocompleteOnSearchSubmit() {
+        return false;
       }
     });
   }

--- a/lib/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
+++ b/lib/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
@@ -1,7 +1,6 @@
 package com.mapzen.pelias.widget;
 
 import android.os.Parcel;
-import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 
 import com.mapzen.pelias.Pelias;

--- a/lib/src/main/java/com/mapzen/pelias/widget/SearchSubmitListener.java
+++ b/lib/src/main/java/com/mapzen/pelias/widget/SearchSubmitListener.java
@@ -1,0 +1,21 @@
+package com.mapzen.pelias.widget;
+
+/**
+ * Interface to override what happens when the search key is pressed.
+ */
+public interface SearchSubmitListener {
+  /**
+   * Return true to have the {@link PeliasSearchView} execute a search when the search key is
+   * pressed, false to do no search.
+   * @return
+   */
+  boolean searchOnSearchKeySubmit();
+
+  /**
+   * Return true to have the {@link PeliasSearchView} hide the autocomplete list view when the
+   * search key is pressed, false to have it remain visible.
+   * @return
+   */
+  boolean hideAutocompleteOnSearchSubmit();
+
+}


### PR DESCRIPTION
### Overview
Adds interface that clients can implement to control whether a search is executed and how to update the autocomplete list view's visibility when the search key is clicked.

### Proposed Changes
- adds `SearchSubmitListener` interface
- refactors `onFocusChange` into smaller methods
- hides list when search key pressed if no `SearchSubmitListener` present or if the listener returns true for `hideAutocompleteOnSearchSubmit` (previously this cleared the search view's focus)
- manually hides/shows search text cursor to account for previous change to behavior
- adds more test coverage

Closes #66 