### PR TITLE
Add Circle CI release config for automated deployments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,4 +22,4 @@ task clean(type: Delete) {
   delete rootProject.buildDir
 }
 
-defaultTasks = ['clean', 'assembleDebug', 'checkstyle', 'copyTask', 'testDebug', 'install']
+defaultTasks = ['clean', 'assembleDebug', 'checkstyle', 'copyTask', 'testDebugUnitTest', 'install']

--- a/circle.yml
+++ b/circle.yml
@@ -24,3 +24,8 @@ deployment:
     branch: master
     commands:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
+  release:
+     tag: /pelias-android-sdk-[0-9]+(\.[0-9]+)*/
+     owner: mapzen
+     commands:
+      - scripts/deploy-staging.sh

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -25,10 +25,10 @@ version = VERSION_NAME
 project.archivesBaseName = POM_ARTIFACT_ID
 
 release {
+  tagTemplate = 'pelias-android-sdk-${version}'
+  versionPropertyFile = '../gradle.properties'
   versionProperties = ['VERSION_NAME']
 }
-
-afterReleaseBuild.dependsOn uploadArchives
 
 task checkstyle(type: Checkstyle) {
   configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Builds, signs, and uploads release AARs to https://oss.sonatype.org/#stagingRepositories.
+#
+
+echo -e "machine github.com\n  login $GITHUB_USERNAME\n  password $GITHUB_PASSWORD" >> ~/.netrc
+git clone https://github.com/mapzen/android-config.git
+./gradlew uploadArchives -PsonatypeUsername="$SONATYPE_NEXUS_SNAPSHOTS_USERNAME" \
+    -PsonatypePassword="$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD" \
+    -Psigning.keyId="$SIGNING_KEY_ID" \
+    -Psigning.password="$SIGNING_PASSWORD" \
+    -Psigning.secretKeyRingFile="$SIGNING_SECRET_KEY_RING_FILE"


### PR DESCRIPTION
### Overview

Adds build config to automate AAR release from Circle CI.

### Proposed Changes

* Updates gradle-release plugin config.
* Updates gradle default tasks to run debug unit tests only.
* Adds release deployment section to `circle.yml`.
* Adds `deploy-staging.sh` to build, sign, and upload release AAR to Sonatype staging repo.