### PR TITLE
Enable TLS 1.2 on pre-lollipop devices

### DIFF
--- a/app/src/main/java/com/mapzen/sample/pelias/MainActivity.java
+++ b/app/src/main/java/com/mapzen/sample/pelias/MainActivity.java
@@ -55,6 +55,7 @@ public class MainActivity extends AppCompatActivity {
 
   private void setupPelias() {
     pelias = new Pelias();
+    pelias.setDebug(true);
     pelias.setLocationProvider(peliasLocationProvider);
   }
 

--- a/lib/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/lib/src/main/java/com/mapzen/pelias/Pelias.java
@@ -1,6 +1,7 @@
 package com.mapzen.pelias;
 
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.pelias.http.Tls12OkHttpClientFactory;
 
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -51,8 +52,8 @@ public class Pelias {
       requestInterceptor.setRequestHandler(requestHandler);
     }
 
-    final OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
-    clientBuilder.addNetworkInterceptor(requestInterceptor);
+    final OkHttpClient.Builder clientBuilder = Tls12OkHttpClientFactory.enableTls12OnPreLollipop(
+        new OkHttpClient.Builder().addNetworkInterceptor(requestInterceptor));
 
     if (debug) {
       final HttpLoggingInterceptor logging = new HttpLoggingInterceptor();

--- a/lib/src/main/java/com/mapzen/pelias/http/Tls12OkHttpClientFactory.java
+++ b/lib/src/main/java/com/mapzen/pelias/http/Tls12OkHttpClientFactory.java
@@ -1,0 +1,64 @@
+package com.mapzen.pelias.http;
+
+import android.os.Build;
+import android.util.Log;
+
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
+/**
+ * Enables TLS 1.2 support for pre-lollipop on {@link OkHttpClient.Builder} objects.
+ */
+public class Tls12OkHttpClientFactory {
+
+  /**
+   * Enables TLS 1.2 support for pre-lollipop on given {@link OkHttpClient.Builder}.
+   * @param client Client to enable TLS on.
+   * @return TLS enabled client.
+   */
+  public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
+    if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+      try {
+        SSLContext sc = SSLContext.getInstance("TLSv1.2");
+        sc.init(null, null, null);
+
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+            TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init((KeyStore) null);
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+        if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+          throw new IllegalStateException("Unexpected default trust managers:"
+              + Arrays.toString(trustManagers));
+        }
+        X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
+        client.sslSocketFactory(new Tls12SocketFactory(sc.getSocketFactory()), trustManager);
+
+        ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.TLS_1_2)
+            .build();
+
+        List<ConnectionSpec> specs = new ArrayList<>();
+        specs.add(cs);
+        specs.add(ConnectionSpec.COMPATIBLE_TLS);
+        specs.add(ConnectionSpec.CLEARTEXT);
+
+        client.connectionSpecs(specs);
+      } catch (Exception exc) {
+        Log.e("OkHttpTLSCompat", "Error while setting TLS 1.2", exc);
+      }
+    }
+
+    return client;
+  }
+}

--- a/lib/src/main/java/com/mapzen/pelias/http/Tls12SocketFactory.java
+++ b/lib/src/main/java/com/mapzen/pelias/http/Tls12SocketFactory.java
@@ -1,0 +1,71 @@
+package com.mapzen.pelias.http;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * From https://github.com/square/okhttp/issues/2372.
+ *
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p/>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+  private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+  final SSLSocketFactory delegate;
+
+  public Tls12SocketFactory(SSLSocketFactory base) {
+    this.delegate = base;
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return delegate.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return delegate.getSupportedCipherSuites();
+  }
+
+  @Override
+  public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+    return patch(delegate.createSocket(s, host, port, autoClose));
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+    return patch(delegate.createSocket(host, port));
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+    return patch(delegate.createSocket(host, port, localHost, localPort));
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port) throws IOException {
+    return patch(delegate.createSocket(host, port));
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+    return patch(delegate.createSocket(address, port, localAddress, localPort));
+  }
+
+  private Socket patch(Socket s) {
+    if (s instanceof SSLSocket) {
+      ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+    }
+    return s;
+  }
+}


### PR DESCRIPTION
### Overview
Enables TLS 1.2 on pre-lollipop devices and updates the sample activity to log requests in debug mode

### Proposed Changes
TLS 1.2 is disabled by default on devices running OS versions below 5.0. Coupled with Fastly upgrading to TLS 1.2, SSL is broken on devices running pre-lollipop OS versions. This change enables TLS 1.2 as recommended here: https://github.com/square/okhttp/issues/2372#issuecomment-244807676

Confirmed that before this change, requests fail with the error below (tested on device running Galaxy Nexus 4.3):
```
05-25 11:48:33.551 3220-3220/com.mapzen.pelias E/PeliasSearchView: Unable to fetch autocomplete results
                                                                   javax.net.ssl.SSLHandshakeException: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0x4183b860: Failure in SSL library, usually a protocol error
                                                                   error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version (external/openssl/ssl/s23_clnt.c:741 0x5bb246a2:0x00000000)
                                                                       at org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:440)
                                                                       at okhttp3.internal.connection.RealConnection.connectTls(RealConnection.java:242)
                                                                       at okhttp3.internal.connection.RealConnection.establishProtocol(RealConnection.java:200)
                                                                       at okhttp3.internal.connection.RealConnection.buildConnection(RealConnection.java:174)
                                                                       at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:114)
                                                                       at okhttp3.internal.connection.StreamAllocation.findConnection(StreamAllocation.java:196)
                                                                       at okhttp3.internal.connection.StreamAllocation.findHealthyConnection(StreamAllocation.java:132)
                                                                       at okhttp3.internal.connection.StreamAllocation.newStream(StreamAllocation.java:101)
                                                                       at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:42)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
                                                                       at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
                                                                       at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
                                                                       at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:120)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
                                                                       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
                                                                       at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:179)
                                                                       at okhttp3.RealCall$AsyncCall.execute(RealCall.java:129)
                                                                       at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
                                                                       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
                                                                       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
                                                                       at java.lang.Thread.run(Thread.java:841)
                                                                   	Suppressed: javax.net.ssl.SSLHandshakeException: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0x58e9d658: Failure in SSL library, usually a protocol error
                                                                   error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version (external/openssl/ssl/s23_clnt.c:741 0x5bb246a2:0x00000000)
                                                                   		... 25 more
                                                                   	Caused by: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0x58e9d658: Failure in SSL library, usually a protocol error
                                                                   error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version (external/openssl/ssl/s23_clnt.c:741 0x5bb246a2:0x00000000)
                                                                       at org.apache.harmony.xnet.provider.jsse.NativeCrypto.SSL_do_handshake(Native Method)
                                                                       at org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:398)
                                                                       		... 24 more
                                                                    Caused by: javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0x4183b860: Failure in SSL library, usually a protocol error
                                                                   error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version (external/openssl/ssl/s23_clnt.c:741 0x5bb246a2:0x00000000)
                                                                       at org.apache.harmony.xnet.provider.jsse.NativeCrypto.SSL_do_handshake(Native Method)
                                                                       at org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:398)
                                                                       	... 24 more

```

Closes #75 